### PR TITLE
🐛 Bug Fix: PayloadTooLargeError when saving large files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,6 @@ app.set('trust proxy', true);
 ----------------------------- */
 
 app.use(cookieParser());
-app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
 // HTMX: disable caching for fragment responses


### PR DESCRIPTION
When attempting to save files larger than 100kb in the editor, the application throws a `PayloadTooLargeError` due to Express.js body parser middleware configuration.

> Express processes middleware in registration order, not in route-specific priority.

I didn't tested how it influence other routes. If it will cause any problems I suppose `app.use(express.json());` can be moved somewhere below routes use.